### PR TITLE
Add key-spacing rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,8 @@ plugins:
 - simple-import-sort
 - '@typescript-eslint/eslint-plugin'
 rules:
+  key-spacing:
+  - 1
   arrow-spacing:
   - 1
   eqeqeq:


### PR DESCRIPTION
We want to have a space between keys and values when declaring objects.