### PR TITLE
Add prettier-config, and new instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ our Javascript/Typescript projects.
 
 Install the config from NPM by using the following command:
 
-`npm install --save-dev @kinvolk/eslint-config`
+`npm install --save-dev @kinvolk/eslint-config eslint-config-prettier`
 
 Install also the peer dependencies NPM suggested (if they're not installed
 automatically).
 
-Then, create an eslint config file with that extends the Kinvolk's one. If you
-prefer YAML, like we do, then create `.eslintrc.yml` with the following
-contents:
+You can include it in your `package.json` file like the following:
 
-```YAML
-extends: '@kinvolk'
+```js
+  "eslintConfig": {
+    "extends": ["@kinvolk", "prettier", "prettier/react"]
+  },
+  "prettier": "@kinvolk/eslint-config/prettier-config",
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinvolk/eslint-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,12 @@
         "v8-compile-cache": "^2.0.3"
       }
     },
+    "eslint-config-prettier": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+      "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+      "dev": true
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "@kinvolk/eslint-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Lint rules for all Kinvolk's Js/Ts projects",
   "main": "index.js",
+  "files": [
+    "prettier-config",
+    "index.js",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "create": "node ./export.js > ./index.js && eslint ./index.js --fix",
-    "lint": "eslint ./export.js"
+    "lint": "eslint ./export.js prettier-config/index.js"
   },
   "repository": {
     "type": "git",
@@ -14,6 +20,7 @@
   "keywords": [
     "eslint",
     "eslintconfig",
+    "prettierconfig",
     "kinvolk"
   ],
   "author": "Joaquim Rocha <joaquim@kinvolk.io>",
@@ -24,6 +31,7 @@
   "homepage": "https://github.com/kinvolk/eslint-config#readme",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "eslint-config-prettier": "^7.2.0",
     "eslint": "^7.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-react": "^7.20.0",
@@ -32,6 +40,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",

--- a/prettier-config/index.js
+++ b/prettier-config/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  arrowParens: 'avoid',
+  singleQuote: true,
+  semi: true,
+  printWidth: 100,
+};
+


### PR DESCRIPTION
# Add prettier-config, and new instructions to README.md

So that eslint and prettier get along nicely. Includes some config for both.

# How to use

In this package you can try it locally before publishing by:

`npm link`

Then in the package using this:

`npm link "@kinvolk/eslint-config"`

# Testing done

Tested locally with the headlamp PR at https://github.com/kinvolk/headlamp/pull/186
